### PR TITLE
Feature/new cancel logic

### DIFF
--- a/lib/ann.js
+++ b/lib/ann.js
@@ -1,3 +1,4 @@
+var util = require('util');
 // Copyright 2016 Zipscene, LLC
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
@@ -620,7 +621,7 @@ ANN.prototype.save = asyncOpQueue(function(filename, toFixed) {
 // Options for non-cascading: maxEpochs (default 2000000000), progressInerval, desiredError
 // progress is an optional callback that is periodically called for multi-epoch training.  It receives a single
 //   parameter: an object containing the keys "iteration" (current epoch or neuron), "mse", and "bitfail".  If
-//   this progress function returns false or -1, training is cancelled on the next iteration.
+//   this progress function returns false or -1, training is canceled on the next iteration.
 //   Instead of a function, you can instead pass the special value "default", to enable the default libfann
 //   behavior of printing out progress information.
 ANN.prototype.train = asyncOpQueue(function(data, options, progress) {
@@ -667,7 +668,12 @@ ANN.prototype.train = asyncOpQueue(function(data, options, progress) {
 	}
 	return new Promise(function(resolve, reject) {
 		var cb = function(err, res) {
-			if (err) return reject(new XError(err));
+			if (err && !res) return reject(new XError(err));
+			self._recalculateInfo();
+			if (err && err.message === 'canceled') {
+				self.userData.canceled = true;
+				self.info.canceled = true;
+			}
 			resolve(res);
 		};
 		var args = [

--- a/lib/ann.js
+++ b/lib/ann.js
@@ -1,4 +1,3 @@
-var util = require('util');
 // Copyright 2016 Zipscene, LLC
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/src/fanny.cc
+++ b/src/fanny.cc
@@ -189,8 +189,8 @@ public:
 	void HandleOKCallback() {
 		Nan::HandleScope scope;
 		if (fanny->cancelTrainingFlag) {
-			v8::Local<v8::Value> errorArgs[] = { Nan::Error("canceled") };
-			callback->Call(1, errorArgs);
+			v8::Local<v8::Value> args[] = { Nan::Error("canceled"), Nan::New(retVal) };
+			callback->Call(2, args);
 			return;
 		}
 		v8::Local<v8::Value> args[] = { Nan::Null(), Nan::New(retVal) };


### PR DESCRIPTION
Handle training cancellation in way that maintains the ANN information but still indicates that the training was stopped early. 