### PR TITLE
fix/training data mem leak

### DIFF
--- a/src/training-data.h
+++ b/src/training-data.h
@@ -28,6 +28,9 @@ private:
 	explicit TrainingData(FANN::training_data *training_data);
 	~TrainingData();
 
+	// Training Data size helper
+	static int getTrainingDataByteCount(TrainingData *td);
+
 	// Methods
 	static NAN_METHOD(shuffle);
 	static NAN_METHOD(merge);


### PR DESCRIPTION
Using https://github.com/nodejs/nan/blob/master/doc/v8_internals.md#api_nan_adjust_external_memory to inform V8 of the size of the traing data objects makes it much more likely that it will get cleaned up in GC. Let me know if there is a better way to organize this logic seems like a bother to have to do it in all these different places.